### PR TITLE
Rearrange config variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,14 +29,15 @@
 # The variables below the "Settings" header can be altered to change the build
 # behavior. Their meaning is as follows:
 
+# BINNAME_R  The name of the generated release binary
+# BINNAME_D  The name of the genereated debug binary
+
 # CXX        The C++ compiler
 # CXXFLAGS   Compiler flags, both for building object files and linking them
 # FLAGS_R    Release-specific compiler flags
 # FLAGS_D    Debug-specific compiler flags
 # LDFLAGS    Compiler flags used when linking the the binary
 # INCFLAGS   Compiler flags for file inclusion; used for building object files
-# BINNAME_R  The name of the generated release binary
-# BINNAME_D  The name of the genereated debug binary
 
 # BINDIR     Directory in which the binaries are placed
 # SRCDIR     Directory in which to look for C++ source files
@@ -58,16 +59,15 @@
 #---------------------------------- Settings ----------------------------------#
 #==============================================================================#
 
-CXX       = g++
+BINNAME_R = BINARYNAME_PLACEHOLDER
+BINNAME_D = $(BINNAME_R)_debug
 
+CXX       = g++
 CXXFLAGS  = -std=c++17 -Wall -Wextra -Wignored-qualifiers
 FLAGS_R   = -O2
 FLAGS_D   = -g
 LDFLAGS   =
 INCFLAGS  = -I include
-
-BINNAME_R = BINARYNAME_PLACEHOLDER
-BINNAME_D = $(BINNAME_R)_debug
 
 BINDIR    = bin
 SRCDIR    = src


### PR DESCRIPTION
Moved the binary names to the top and grouped CXX with the various flag variables.

The binary names are the variables that the user will most often change: they are the only variables that will be different for almost every project. Therefore, they should be at the top. The newproject script does set these variables automatically, but users may not always use the script.

The grouping of the variables in the usage instructions is now also the same as in the settings.

This branch contains the branch from #13, so #13 should be merged or closed first.