### PR TITLE
Add extra flags to `FLAGS_R` and `FLAGS_D`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,8 @@ BINNAME_D = $(BINNAME_R)_debug
 
 CXX       = g++
 CXXFLAGS  = -std=c++17 -Wall -Wextra -Wignored-qualifiers
-FLAGS_R   = -O2
-FLAGS_D   = -g
+FLAGS_R   = -O2 -DNDEBUG
+FLAGS_D   = -Og -g3 -DDEBUG
 LDFLAGS   =
 INCFLAGS  = -I include
 


### PR DESCRIPTION
The flag `-DNDEBUG` was added to `FLAGS_R` because the `NDEBUG` define
is commonly used to signify that we don't want debug code.

The flag `-DDEBUG` was added to `FLAGS_D` because the `DEBUG` define is
commonly used to signify that we want debug code.

The flag `-Og` was added to `FLAGS_D` to ensure all compiler passes
useful for debugging are run.

The flag `-g` was changed to `-g3` to include extra debugging
information, such as all the macro definitions present in the program.